### PR TITLE
Add space before separator character

### DIFF
--- a/theme.bash
+++ b/theme.bash
@@ -216,7 +216,7 @@ function __powerline_prompt_command {
     [[ -n "${info}" ]] && __powerline_left_segment "${info}"
   done
 
-  [[ -n "${LEFT_PROMPT}" ]] && LEFT_PROMPT+="$(__color - ${LAST_SEGMENT_COLOR})${separator_char}$(__color)"
+  [[ -n "${LEFT_PROMPT}" ]] && LEFT_PROMPT+=" $(__color - ${LAST_SEGMENT_COLOR})${separator_char}$(__color)"
   PS1="${LEFT_PROMPT} "
 
   ## cleanup ##


### PR DESCRIPTION
When using this theme, the text from things such as the present working directory ends up feeling very squished against the separator character, at times making the text a little more less clear and harder to read. This PR adds a space before the separator character is used, to keep everything nicely spaced out and looking consistent.