### PR TITLE
Speed up last_status by avoiding wc -l

### DIFF
--- a/theme.bash
+++ b/theme.bash
@@ -197,7 +197,7 @@ function __powerline_last_status_prompt {
   local symbols=()
   [[ $last_status -ne 0 ]] && symbols+="$(__color ${STATUS_PROMPT_ERROR_COLOR})${STATUS_PROMPT_ERROR}"
   [[ $UID -eq 0 ]] && symbols+="$(__color ${STATUS_PROMPT_ROOT_COLOR})${STATUS_PROMPT_ROOT}"
-  [[ ! -z $(read -r line <<< $(jobs -l); echo $line) ]] && symbols+="$(__color ${STATUS_PROMPT_JOBS_COLOR})${STATUS_PROMPT_JOBS}"
+  [[ ! -z $(read -r -n1 stopped_jobs <<< $(jobs -sp); echo $stopped_jobs) ]] && symbols+="$(__color ${STATUS_PROMPT_JOBS_COLOR})${STATUS_PROMPT_JOBS}"
 
   [[ -n "$symbols" ]] && echo "$symbols|${STATUS_PROMPT_COLOR}"
 }

--- a/theme.bash
+++ b/theme.bash
@@ -194,10 +194,12 @@ function __powerline_left_segment {
 }
 
 function __powerline_last_status_prompt {
-  local symbols=()
+  local symbols=()  
+  local stopped_jobs
+  jobs -sp | read -n1 stopped_jobs
   [[ $last_status -ne 0 ]] && symbols+="$(__color ${STATUS_PROMPT_ERROR_COLOR})${STATUS_PROMPT_ERROR}"
   [[ $UID -eq 0 ]] && symbols+="$(__color ${STATUS_PROMPT_ROOT_COLOR})${STATUS_PROMPT_ROOT}"
-  [[ ! -z $(read -r -n1 stopped_jobs <<< $(jobs -sp); echo $stopped_jobs) ]] && symbols+="$(__color ${STATUS_PROMPT_JOBS_COLOR})${STATUS_PROMPT_JOBS}"
+  [[ ! -z "$stopped_jobs" ]] && symbols+="$(__color ${STATUS_PROMPT_JOBS_COLOR})${STATUS_PROMPT_JOBS}"
 
   [[ -n "$symbols" ]] && echo "$symbols|${STATUS_PROMPT_COLOR}"
 }

--- a/theme.bash
+++ b/theme.bash
@@ -196,7 +196,7 @@ function __powerline_left_segment {
 function __powerline_last_status_prompt {
   local symbols=()  
   local stopped_jobs
-  jobs -sp | read -n1 stopped_jobs
+  read -N1 stopped_jobs < <(jobs -sp)
   [[ $last_status -ne 0 ]] && symbols+="$(__color ${STATUS_PROMPT_ERROR_COLOR})${STATUS_PROMPT_ERROR}"
   [[ $UID -eq 0 ]] && symbols+="$(__color ${STATUS_PROMPT_ROOT_COLOR})${STATUS_PROMPT_ROOT}"
   [[ ! -z "$stopped_jobs" ]] && symbols+="$(__color ${STATUS_PROMPT_JOBS_COLOR})${STATUS_PROMPT_JOBS}"

--- a/theme.bash
+++ b/theme.bash
@@ -197,7 +197,7 @@ function __powerline_last_status_prompt {
   local symbols=()
   [[ $last_status -ne 0 ]] && symbols+="$(__color ${STATUS_PROMPT_ERROR_COLOR})${STATUS_PROMPT_ERROR}"
   [[ $UID -eq 0 ]] && symbols+="$(__color ${STATUS_PROMPT_ROOT_COLOR})${STATUS_PROMPT_ROOT}"
-  [[ $(jobs -l | wc -l) -gt 0 ]] && symbols+="$(__color ${STATUS_PROMPT_JOBS_COLOR})${STATUS_PROMPT_JOBS}"
+  [[ ! -z $(read -r line <<< $(jobs -l); echo $line) ]] && symbols+="$(__color ${STATUS_PROMPT_JOBS_COLOR})${STATUS_PROMPT_JOBS}"
 
   [[ -n "$symbols" ]] && echo "$symbols|${STATUS_PROMPT_COLOR}"
 }


### PR DESCRIPTION
On my system using native bash functions instead of wc -l speeds up the last_status by about 0.2 seconds.   This may be because windows pipes are slow or some issue with wc.

Before:
```
 master
last_status: 0.463
user_info: 0.066
cwd: 0.071
scm: 2.549
```

After:
```
last_status: 0.228
user_info: 0.079
cwd: 0.073
scm: 2.714
```

Performance numbers aren't exact as they vary a bit, but you can see a bit difference in the runtime for last_status.