### PR TITLE
feature: Add NPM package segment

### DIFF
--- a/theme.bash
+++ b/theme.bash
@@ -6,15 +6,21 @@
 # Git code based on https://github.com/joeytwiddle/git-aware-prompt/blob/master/prompt.sh
 # More info about color codes in https://en.wikipedia.org/wiki/ANSI_escape_code
 
+MULTILINE="YES" # set to "YES" to put add a \n before and after the prompt
+SHORT_USER_INFO="YES" # set to "YES" to omit the hostname
+SHORT_CWD="YES" # set to "YES" to show only the basename of the CWD
+PADDING=" " # use this character sequence to pad the segments around the separators
 
 PROMPT_CHAR=${POWERLINE_PROMPT_CHAR:=""}
-POWERLINE_LEFT_SEPARATOR=" "
-POWERLINE_PROMPT="last_status user_info cwd scm"
+POWERLINE_LEFT_SEPARATOR="${PADDING}"
+POWERLINE_PROMPT="last_status user_info cwd npm scm"
 
-USER_INFO_SSH_CHAR=" "
-USER_INFO_PROMPT_COLOR="C B"
+USER_INFO_SSH_CHAR="${PADDING}"
+USER_INFO_PROMPT_COLOR="C Bl"
 
-SCM_GIT_CHAR=" "
+NPM_PROMPT_COLOR="Y Bl"
+
+SCM_GIT_CHAR="${PADDING}"
 SCM_PROMPT_CLEAN=""
 SCM_PROMPT_DIRTY="*"
 SCM_PROMPT_AHEAD="↑"
@@ -27,7 +33,7 @@ SCM_PROMPT_STAGED_COLOR="Y Bl"
 SCM_PROMPT_UNSTAGED_COLOR="R Bl"
 SCM_PROMPT_COLOR=${SCM_PROMPT_CLEAN_COLOR}
 
-CWD_PROMPT_COLOR="B C"
+CWD_PROMPT_COLOR="B Bl"
 
 STATUS_PROMPT_COLOR="Bl R B"
 STATUS_PROMPT_ERROR="✘"
@@ -78,16 +84,70 @@ function __color {
 function __powerline_user_info_prompt {
   local user_info=""
   local color=${USER_INFO_PROMPT_COLOR}
+  local hostname_escape="@\\h"
+  [[ "$SHORT_USER_INFO" == "YES" ]] && hostname_escape=""
   if [[ -n "${SSH_CLIENT}" ]]; then
-    user_info="${USER_INFO_SSH_CHAR}\u@\h"
+    user_info="${USER_INFO_SSH_CHAR}\u${hostname_escape}"
   else
-    user_info="\u@\h"
+    user_info="\u${hostname_escape}"
   fi
-  [[ -n "${user_info}" ]] && echo "${user_info}|${color}"
+  [[ -n "${user_info}" ]] && echo "${PADDING}${user_info}${PADDING}|${color}"
 }
 
 function __powerline_cwd_prompt {
-  echo "\w|${CWD_PROMPT_COLOR}"
+  local cwd_escape="\\w"
+  [[ "$SHORT_CWD" == "YES" ]] && cwd_escape="\\W"
+  echo "${cwd_escape}${PADDING}|${CWD_PROMPT_COLOR}"
+}
+
+function __powerline_npm_prompt {
+  npm_package_file_name="package.json"
+  npm_package_file=""
+  git_top_level=""
+  npm_name=""
+  npm_version=""
+
+  find_git_top_level() {
+    git_top_level=$(git rev-parse --show-toplevel 2> /dev/null)
+    return 0
+  }
+
+  find_npm_package_file() {
+    npm_package_file="$npm_package_file_name"
+    if [ -n "$git_top_level" ]; then
+      git_top_level=$(sed 's/\([A-Za-z]\):/\/\L\1/' <<< "${git_top_level}")
+      npm_package_file="${git_top_level}/${npm_package_file}"
+    fi
+    if [ ! -f "$npm_package_file" ]; then
+      npm_package_file=""
+      return 1
+    fi
+  }
+
+  find_npm_name() {
+    if [[ -n "$npm_package_file" ]]; then
+      npm_name=$(awk -F '"' '/name/ {print $4}' $npm_package_file)
+    fi
+  }
+
+  find_npm_version() {
+    if [[ -n "$npm_package_file" ]]; then
+      npm_version=$(awk -F '"' '/version/ {print $4}' $npm_package_file)
+    fi
+  }
+
+  local color
+  local npm_info
+
+  find_git_top_level && find_npm_package_file && find_npm_name && find_npm_version
+
+  # not in NPM package
+  [[ -z "$npm_package_file" ]] && return
+
+  npm_info="${npm_name}@${npm_version}"
+  color=${NPM_PROMPT_COLOR}
+
+  [[ "$npm_info" != "@" ]] && echo "${npm_info}${PADDING}|${color}"
 }
 
 function __powerline_scm_prompt {
@@ -168,7 +228,7 @@ function __powerline_scm_prompt {
   [[ -n "$git_behind" ]] && scm_info+="${SCM_PROMPT_BEHIND}${git_behind_count}"
   [[ -n "$git_ahead" ]] && scm_info+="${SCM_PROMPT_AHEAD}${git_ahead_count}"
 
-  [[ -n "${scm_info}" ]] && echo "${scm_info}|${color}"
+  [[ -n "${scm_info}" ]] && echo "${scm_info}${PADDING}|${color}"
 }
 
 function __powerline_left_segment {
@@ -195,9 +255,11 @@ function __powerline_left_segment {
 
 function __powerline_last_status_prompt {
   local symbols=()
+  local stopped_jobs
+  read -N1 stopped_jobs < <(jobs -sp)
   [[ $last_status -ne 0 ]] && symbols+="$(__color ${STATUS_PROMPT_ERROR_COLOR})${STATUS_PROMPT_ERROR}"
   [[ $UID -eq 0 ]] && symbols+="$(__color ${STATUS_PROMPT_ROOT_COLOR})${STATUS_PROMPT_ROOT}"
-  [[ $(jobs -l | wc -l) -gt 0 ]] && symbols+="$(__color ${STATUS_PROMPT_JOBS_COLOR})${STATUS_PROMPT_JOBS}"
+  [[ ! -z "$stopped_jobs" ]] && symbols+="$(__color ${STATUS_PROMPT_JOBS_COLOR})${STATUS_PROMPT_JOBS}"
 
   [[ -n "$symbols" ]] && echo "$symbols|${STATUS_PROMPT_COLOR}"
 }
@@ -205,6 +267,8 @@ function __powerline_last_status_prompt {
 function __powerline_prompt_command {
   local last_status="$?" ## always the first
   local separator_char="${POWERLINE_PROMPT_CHAR}"
+
+  [[ "$MULTILINE" == "YES" ]] && separator_char="${POWERLINE_LEFT_SEPARATOR}"
 
   LEFT_PROMPT=""
   SEGMENTS_AT_LEFT=0
@@ -217,7 +281,10 @@ function __powerline_prompt_command {
   done
 
   [[ -n "${LEFT_PROMPT}" ]] && LEFT_PROMPT+="$(__color - ${LAST_SEGMENT_COLOR})${separator_char}$(__color)"
-  PS1="${LEFT_PROMPT} "
+
+  [[ "$MULTILINE" == "YES" ]] \
+    && PS1="\n${LEFT_PROMPT}\n\$ " \
+    || PS1="${LEFT_PROMPT} "
 
   ## cleanup ##
   unset LAST_SEGMENT_COLOR \


### PR DESCRIPTION
- Show NPM package name@version segment, if package.json is detected
- Add optional multiline capability (linebreak before and after prompt)
- Add optional short CWD display capability
- Add optional padding character sequence
- Change text color to black, for legibility across more terminal themes
- Incorporate change from PR#3 to speed up last_status